### PR TITLE
Small clarification to code based on discussions at infero

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ function processAttributes(t, attributes, root, templateElem) {
 				}
 				else if (!attributeValue.type){
 					root.templateString += attrName + "=''|-|";
-					templateElem.attrs[attrName] = '';
+					templateElem.attrs[attrName] = true;
 				}
 			} else if (attribute.type === 'JSXSpreadAttribute') {
 				var argument = attribute.argument;


### PR DESCRIPTION
This PR is a small clarification based on the result of the [discussions here](https://github.com/trueadm/inferno/pull/126).  A value of true is necessary once a boolean attribute enters the flow within InfernoDom - [specifically here](https://github.com/trueadm/inferno/pull/126/files#diff-ad25e7754303d7b8e5cd4a98c3056be1R39).  This addition is required to complete a 2-part fix for supporting boolean attributes as per the html spec.