### PR TITLE
Added conversion of camel case and (erroneous) sentence case JSXAttributes to hyphen separated names

### DIFF
--- a/lib/constructTemplateNode.js
+++ b/lib/constructTemplateNode.js
@@ -128,7 +128,10 @@ function constructTemplateNode(t, node, isRoot) {
 
 				if (attrKeys.length > 0 || (spreadKeys && spreadKeys.length > 0)) {
 					const attrsObject = t.ObjectExpression(attrKeys.map(function (attrKey) {
-						return t.ObjectProperty(hasHyphenOrColon(attrKey) ? t.StringLiteral(attrKey) : t.identifier(attrKey), getObjectValue(t, attrs[attrKey]));
+						let proposedAttr = attrKey.replace(/([A-Z])/g, function(str, match, index) {
+							return index ? '-' + match : match;
+						}).toLowerCase();
+						return t.ObjectProperty(hasHyphenOrColon(proposedAttr) ? t.StringLiteral(proposedAttr) : t.identifier(proposedAttr), getObjectValue(t, attrs[attrKey]));
 					}));
 					if (spread) {
 						template.push(t.ObjectProperty(t.identifier('attrs'), t.ObjectExpression([t.SpreadProperty(attrsObject)].concat(spreadKeys.map(spread => t.SpreadProperty(t.identifier(spread)))))));


### PR DESCRIPTION
```js
<div dataCustomData="custom" AriaSelected="true" ></div>
```
Yields 
```js
<div data-custom-data="custom" aria-selected="true" ></div>
```